### PR TITLE
修复某些机型打开"我的页面"空白的问题

### DIFF
--- a/lib/pages/profile/profile_page.dart
+++ b/lib/pages/profile/profile_page.dart
@@ -199,8 +199,9 @@ class ProfilePage extends GetView<ProfileController> with ToastMixin {
             // Tab栏
             SliverPersistentHeader(
               pinned: true,
-              delegate: StickyTabBarDelegate(
-                height: 40.w,
+              delegate: _SliverAppBarDelegate(
+                minHeight: 40.w,
+                maxHeight: 40.w,
                 child: Container(
                   decoration: BoxDecoration(
                     color: AppColors.transparent,
@@ -512,5 +513,41 @@ class ProfilePage extends GetView<ProfileController> with ToastMixin {
         ),
       ),
     );
+  }
+}
+
+class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
+  final double minHeight;
+  final double maxHeight;
+  final Widget child;
+
+  _SliverAppBarDelegate({
+    required this.minHeight,
+    required this.maxHeight,
+    required this.child,
+  });
+
+  @override
+  double get minExtent => minHeight;
+
+  @override
+  double get maxExtent => maxHeight;
+
+  @override
+  Widget build(BuildContext context, double shrinkOffset, bool overlapsContent) {
+    // 使用 clamp 确保不会出现精度问题
+    final double currentExtent = (maxExtent - shrinkOffset).clamp(minExtent, maxExtent);
+    
+    return SizedBox(
+      height: currentExtent,
+      child: child,
+    );
+  }
+
+  @override
+  bool shouldRebuild(_SliverAppBarDelegate oldDelegate) {
+    return maxHeight != oldDelegate.maxHeight ||
+        minHeight != oldDelegate.minHeight ||
+        child != oldDelegate.child;
   }
 }


### PR DESCRIPTION
# 问题报错
```dart
======== Exception caught by rendering library =====================================================
The following assertion was thrown during performLayout():
SliverGeometry is not valid: The "layoutExtent" exceeds the "paintExtent".

The paintExtent is 47.78666666666666, but the layoutExtent is 47.78666666666667.

Maybe you have fallen prey to floating point rounding errors, and should explicitly apply the min() or max() functions, or the clamp() method, to the layoutExtent?

The RenderSliver that returned the offending geometry was: _RenderSliverPinnedPersistentHeaderForWidgets#a2670 relayoutBoundary=up1 NEEDS-LAYOUT NEEDS-PAINT NEEDS-COMPOSITING-BITS-UPDATE
...  parentData: paintOffset=Offset(0.0, 0.0) (can use size)
...  constraints: SliverConstraints(AxisDirection.down, GrowthDirection.forward, ScrollDirection.idle, scrollOffset: 0.0, precedingScrollExtent: 463.7, remainingPaintExtent: 449.7, crossAxisExtent: 448.0, crossAxisDirection: AxisDirection.right, viewportMainAxisExtent: 913.4, remainingCacheExtent: 699.7, cacheOrigin: 0.0)
...  geometry: SliverGeometry(scrollExtent: 47.8, paintExtent: 47.8, layoutExtent: 47.8, maxPaintExtent: 47.8, hasVisualOverflow: true, cacheExtent: 47.8)
...    scrollExtent: 47.8
...    paintExtent: 47.8
...    layoutExtent: 47.8
...    maxPaintExtent: 47.8
...    hasVisualOverflow: true
...    cacheExtent: 47.8
...  maxExtent: 47.8
...  child position: 0.0
The relevant error-causing widget was: 
  SliverPersistentHeader SliverPersistentHeader:file:///C:/Users/Jooooody/Documents/Linux-DO/lib/pages/profile/profile_page.dart:200:13
When the exception was thrown, this was the stack: 
#0      SliverGeometry.debugAssertIsValid.<anonymous closure>.verify (package:flutter/src/rendering/sliver.dart:868:9)
#1      SliverGeometry.debugAssertIsValid.<anonymous closure> (package:flutter/src/rendering/sliver.dart:880:9)
#2      SliverGeometry.debugAssertIsValid (package:flutter/src/rendering/sliver.dart:903:6)
#3      RenderSliver.debugAssertDoesMeetConstraints (package:flutter/src/rendering/sliver.dart:1390:17)
#4      RenderObject.layout.<anonymous closure> (package:flutter/src/rendering/object.dart:2718:9)
#5      RenderObject.layout (package:flutter/src/rendering/object.dart:2720:8)
#6      RenderViewportBase.layoutChildSequence (package:flutter/src/rendering/viewport.dart:608:13)
#7      RenderViewport._attemptLayout (package:flutter/src/rendering/viewport.dart:1576:12)
#8      RenderViewport.performLayout (package:flutter/src/rendering/viewport.dart:1467:20)
#9      RenderObject.layout (package:flutter/src/rendering/object.dart:2715:7)
#10     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:115:18)
#11     RenderObject.layout (package:flutter/src/rendering/object.dart:2715:7)
#12     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:115:18)
#13     RenderObject.layout (package:flutter/src/rendering/object.dart:2715:7)
#14     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:115:18)
#15     RenderObject.layout (package:flutter/src/rendering/object.dart:2715:7)
#16     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:115:18)
#17     RenderObject.layout (package:flutter/src/rendering/object.dart:2715:7)
#18     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:115:18)
#19     RenderObject.layout (package:flutter/src/rendering/object.dart:2715:7)
#20     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:115:18)
#21     RenderObject.layout (package:flutter/src/rendering/object.dart:2715:7)
#22     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:115:18)
#23     RenderObject.layout (package:flutter/src/rendering/object.dart:2715:7)
#24     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:115:18)
#25     _RenderCustomClip.performLayout (package:flutter/src/rendering/proxy_box.dart:1483:11)
#26     RenderObject.layout (package:flutter/src/rendering/object.dart:2715:7)
#27     MultiChildLayoutDelegate.layoutChild (package:flutter/src/rendering/custom_layout.dart:180:12)
#28     _ScaffoldLayout.performLayout (package:flutter/src/material/scaffold.dart:1118:7)
#29     MultiChildLayoutDelegate._callPerformLayout (package:flutter/src/rendering/custom_layout.dart:249:7)
#30     RenderCustomMultiChildLayoutBox.performLayout (package:flutter/src/rendering/custom_layout.dart:419:14)
#31     RenderObject.layout (package:flutter/src/rendering/object.dart:2715:7)
#32     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:115:18)
#33     RenderObject.layout (package:flutter/src/rendering/object.dart:2715:7)
#34     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:115:18)
#35     _RenderCustomClip.performLayout (package:flutter/src/rendering/proxy_box.dart:1483:11)
#36     RenderObject.layout (package:flutter/src/rendering/object.dart:2715:7)
#37     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:115:18)
#38     RenderObject.layout (package:flutter/src/rendering/object.dart:2715:7)
#39     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:115:18)
#40     RenderObject.layout (package:flutter/src/rendering/object.dart:2715:7)
#41     ChildLayoutHelper.layoutChild (package:flutter/src/rendering/layout_helper.dart:62:11)
#42     RenderStack._computeSize (package:flutter/src/rendering/stack.dart:646:43)
#43     RenderStack.performLayout (package:flutter/src/rendering/stack.dart:673:12)
#44     RenderObject.layout (package:flutter/src/rendering/object.dart:2715:7)
#45     MultiChildLayoutDelegate.layoutChild (package:flutter/src/rendering/custom_layout.dart:180:12)
#46     _ScaffoldLayout.performLayout (package:flutter/src/material/scaffold.dart:1118:7)
#47     MultiChildLayoutDelegate._callPerformLayout (package:flutter/src/rendering/custom_layout.dart:249:7)
#48     RenderCustomMultiChildLayoutBox.performLayout (package:flutter/src/rendering/custom_layout.dart:419:14)
#49     RenderObject._layoutWithoutResize (package:flutter/src/rendering/object.dart:2548:7)
#50     PipelineOwner.flushLayout (package:flutter/src/rendering/object.dart:1112:18)
#51     PipelineOwner.flushLayout (package:flutter/src/rendering/object.dart:1125:15)
#52     RendererBinding.drawFrame (package:flutter/src/rendering/binding.dart:616:23)
#53     WidgetsBinding.drawFrame (package:flutter/src/widgets/binding.dart:1231:13)
#54     RendererBinding._handlePersistentFrameCallback (package:flutter/src/rendering/binding.dart:482:5)
#55     SchedulerBinding._invokeFrameCallback (package:flutter/src/scheduler/binding.dart:1442:15)
#56     SchedulerBinding.handleDrawFrame (package:flutter/src/scheduler/binding.dart:1355:9)
#57     SchedulerBinding._handleDrawFrame (package:flutter/src/scheduler/binding.dart:1208:5)
#58     _invoke (dart:ui/hooks.dart:316:13)
#59     PlatformDispatcher._drawFrame (dart:ui/platform_dispatcher.dart:428:5)
#60     _drawFrame (dart:ui/hooks.dart:288:31)
The following RenderObject was being processed when the exception was fired: _RenderSliverPinnedPersistentHeaderForWidgets#a2670 relayoutBoundary=up1 NEEDS-LAYOUT NEEDS-PAINT NEEDS-COMPOSITING-BITS-UPDATE
...  parentData: paintOffset=Offset(0.0, 0.0) (can use size)
...  constraints: SliverConstraints(AxisDirection.down, GrowthDirection.forward, ScrollDirection.idle, scrollOffset: 0.0, precedingScrollExtent: 463.7, remainingPaintExtent: 449.7, crossAxisExtent: 448.0, crossAxisDirection: AxisDirection.right, viewportMainAxisExtent: 913.4, remainingCacheExtent: 699.7, cacheOrigin: 0.0)
...  geometry: SliverGeometry(scrollExtent: 47.8, paintExtent: 47.8, layoutExtent: 47.8, maxPaintExtent: 47.8, hasVisualOverflow: true, cacheExtent: 47.8)
...    scrollExtent: 47.8
...    paintExtent: 47.8
...    layoutExtent: 47.8
...    maxPaintExtent: 47.8
...    hasVisualOverflow: true
...    cacheExtent: 47.8
...  maxExtent: 47.8
...  child position: 0.0
RenderObject: _RenderSliverPinnedPersistentHeaderForWidgets#a2670 relayoutBoundary=up1 NEEDS-LAYOUT NEEDS-PAINT NEEDS-COMPOSITING-BITS-UPDATE
  parentData: paintOffset=Offset(0.0, 0.0) (can use size)
  constraints: SliverConstraints(AxisDirection.down, GrowthDirection.forward, ScrollDirection.idle, scrollOffset: 0.0, precedingScrollExtent: 463.7, remainingPaintExtent: 449.7, crossAxisExtent: 448.0, crossAxisDirection: AxisDirection.right, viewportMainAxisExtent: 913.4, remainingCacheExtent: 699.7, cacheOrigin: 0.0)
  geometry: SliverGeometry(scrollExtent: 47.8, paintExtent: 47.8, layoutExtent: 47.8, maxPaintExtent: 47.8, hasVisualOverflow: true, cacheExtent: 47.8)
    scrollExtent: 47.8
    paintExtent: 47.8
    layoutExtent: 47.8
    maxPaintExtent: 47.8
    hasVisualOverflow: true
    cacheExtent: 47.8
  maxExtent: 47.8
  child position: 0.0
...  child: _RenderColoredBox#09aff relayoutBoundary=up2 NEEDS-PAINT NEEDS-COMPOSITING-BITS-UPDATE
...    parentData: <none> (can use size)
...    constraints: BoxConstraints(w=448.0, 0.0<=h<=47.8)
...    size: Size(448.0, 47.8)
...    behavior: opaque
...    child: RenderPadding#3b49d relayoutBoundary=up3 NEEDS-PAINT NEEDS-COMPOSITING-BITS-UPDATE
...      parentData: <none> (can use size)
...      constraints: BoxConstraints(w=448.0, 0.0<=h<=47.8)
...      size: Size(448.0, 47.8)
...      padding: EdgeInsets(0.0, 7.2, 0.0, 7.2)
...      textDirection: ltr
...      child: RenderDecoratedBox#49c8a relayoutBoundary=up4 NEEDS-PAINT NEEDS-COMPOSITING-BITS-UPDATE
...        parentData: offset=Offset(0.0, 7.2) (can use size)
...        constraints: BoxConstraints(w=448.0, 0.0<=h<=33.5)
...        size: Size(448.0, 33.5)
...        decoration: BoxDecoration
...          color: Color(alpha: 0.0000, red: 0.0000, green: 0.0000, blue: 0.0000, colorSpace: ColorSpace.sRGB)
...          borderRadius: BorderRadius.circular(14.3)
...          boxShadow: BoxShadow(Color(alpha: 0.0500, red: 0.0000, green: 0.0000, blue: 0.0000, colorSpace: ColorSpace.sRGB), Offset(0.0, 2.0), 10.0, 0.0, BlurStyle.normal)
...        configuration: ImageConfiguration(bundle: PlatformAssetBundle#848a2(), devicePixelRatio: 3.0, locale: en, textDirection: TextDirection.ltr, platform: android)
...        child: RenderPadding#1f24b relayoutBoundary=up5 NEEDS-PAINT NEEDS-COMPOSITING-BITS-UPDATE
...          parentData: <none> (can use size)
...          constraints: BoxConstraints(w=448.0, 0.0<=h<=33.5)
...          size: Size(448.0, 33.5)
...          padding: EdgeInsets(23.9, 0.0, 23.9, 0.0)
...          textDirection: ltr
====================================================================================================
E/libEGL  ( 6830): called unimplemented OpenGL ES API
D/EGL_emulation( 6830): app_time_stats: avg=607.69ms min=264.46ms max=950.92ms count=2

======== Exception caught by rendering library =====================================================
The following assertion was thrown during performLayout():
SliverGeometry is not valid: The "layoutExtent" exceeds the "paintExtent".

The paintExtent is 47.78666666666666, but the layoutExtent is 47.78666666666667.

Maybe you have fallen prey to floating point rounding errors, and should explicitly apply the min() or max() functions, or the clamp() method, to the layoutExtent?

The relevant error-causing widget was: 
  NestedScrollView NestedScrollView:file:///C:/Users/Jooooody/Documents/Linux-DO/lib/pages/profile/profile_page.dart:48:16
When the exception was thrown, this was the stack: 
#0      SliverGeometry.debugAssertIsValid.<anonymous closure>.verify (package:flutter/src/rendering/sliver.dart:868:9)
#1      SliverGeometry.debugAssertIsValid.<anonymous closure> (package:flutter/src/rendering/sliver.dart:880:9)
#2      SliverGeometry.debugAssertIsValid (package:flutter/src/rendering/sliver.dart:903:6)
#3      RenderViewportBase.layoutChildSequence (package:flutter/src/rendering/viewport.dart:630:34)
#4      RenderViewport._attemptLayout (package:flutter/src/rendering/viewport.dart:1576:12)
#5      RenderViewport.performLayout (package:flutter/src/rendering/viewport.dart:1467:20)
#6      RenderObject.layout (package:flutter/src/rendering/object.dart:2715:7)
#7      RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:115:18)
#8      RenderObject.layout (package:flutter/src/rendering/object.dart:2715:7)
#9      RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:115:18)
#10     RenderObject.layout (package:flutter/src/rendering/object.dart:2715:7)
#11     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:115:18)
#12     RenderObject.layout (package:flutter/src/rendering/object.dart:2715:7)
#13     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:115:18)
#14     RenderObject.layout (package:flutter/src/rendering/object.dart:2715:7)
#15     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:115:18)
#16     RenderObject.layout (package:flutter/src/rendering/object.dart:2715:7)
#17     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:115:18)
#18     RenderObject.layout (package:flutter/src/rendering/object.dart:2715:7)
#19     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:115:18)
#20     RenderObject.layout (package:flutter/src/rendering/object.dart:2715:7)
#21     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:115:18)
#22     _RenderCustomClip.performLayout (package:flutter/src/rendering/proxy_box.dart:1483:11)
#23     RenderObject.layout (package:flutter/src/rendering/object.dart:2715:7)
#24     MultiChildLayoutDelegate.layoutChild (package:flutter/src/rendering/custom_layout.dart:180:12)
#25     _ScaffoldLayout.performLayout (package:flutter/src/material/scaffold.dart:1118:7)
#26     MultiChildLayoutDelegate._callPerformLayout (package:flutter/src/rendering/custom_layout.dart:249:7)
#27     RenderCustomMultiChildLayoutBox.performLayout (package:flutter/src/rendering/custom_layout.dart:419:14)
#28     RenderObject.layout (package:flutter/src/rendering/object.dart:2715:7)
#29     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:115:18)
#30     RenderObject.layout (package:flutter/src/rendering/object.dart:2715:7)
#31     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:115:18)
#32     _RenderCustomClip.performLayout (package:flutter/src/rendering/proxy_box.dart:1483:11)
#33     RenderObject.layout (package:flutter/src/rendering/object.dart:2715:7)
#34     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:115:18)
#35     RenderObject.layout (package:flutter/src/rendering/object.dart:2715:7)
#36     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:115:18)
#37     RenderObject.layout (package:flutter/src/rendering/object.dart:2715:7)
#38     ChildLayoutHelper.layoutChild (package:flutter/src/rendering/layout_helper.dart:62:11)
#39     RenderStack._computeSize (package:flutter/src/rendering/stack.dart:646:43)
#40     RenderStack.performLayout (package:flutter/src/rendering/stack.dart:673:12)
#41     RenderObject.layout (package:flutter/src/rendering/object.dart:2715:7)
#42     MultiChildLayoutDelegate.layoutChild (package:flutter/src/rendering/custom_layout.dart:180:12)
#43     _ScaffoldLayout.performLayout (package:flutter/src/material/scaffold.dart:1118:7)
#44     MultiChildLayoutDelegate._callPerformLayout (package:flutter/src/rendering/custom_layout.dart:249:7)
#45     RenderCustomMultiChildLayoutBox.performLayout (package:flutter/src/rendering/custom_layout.dart:419:14)
#46     RenderObject._layoutWithoutResize (package:flutter/src/rendering/object.dart:2548:7)
#47     PipelineOwner.flushLayout (package:flutter/src/rendering/object.dart:1112:18)
#48     PipelineOwner.flushLayout (package:flutter/src/rendering/object.dart:1125:15)
#49     RendererBinding.drawFrame (package:flutter/src/rendering/binding.dart:616:23)
#50     WidgetsBinding.drawFrame (package:flutter/src/widgets/binding.dart:1231:13)
#51     RendererBinding._handlePersistentFrameCallback (package:flutter/src/rendering/binding.dart:482:5)
#52     SchedulerBinding._invokeFrameCallback (package:flutter/src/scheduler/binding.dart:1442:15)
#53     SchedulerBinding.handleDrawFrame (package:flutter/src/scheduler/binding.dart:1355:9)
#54     SchedulerBinding._handleDrawFrame (package:flutter/src/scheduler/binding.dart:1208:5)
#55     _invoke (dart:ui/hooks.dart:316:13)
#56     PlatformDispatcher._drawFrame (dart:ui/platform_dispatcher.dart:428:5)
#57     _drawFrame (dart:ui/hooks.dart:288:31)
The following RenderObject was being processed when the exception was fired: RenderNestedScrollViewViewport#d1d57 NEEDS-LAYOUT NEEDS-PAINT NEEDS-COMPOSITING-BITS-UPDATE
...  needs compositing
...  parentData: <none> (can use size)
...  constraints: BoxConstraints(0.0<=w<=448.0, 0.0<=h<=913.4)
...  size: Size(448.0, 913.4)
...  axisDirection: down
...  crossAxisDirection: right
...  offset: _NestedScrollPosition#bae9f(outer, offset: 0.0, range: null..null, viewport: 913.4)
...  anchor: 0.0
...  handle: SliverOverlapAbsorberHandle(null, orphan)
RenderObject: RenderNestedScrollViewViewport#d1d57 NEEDS-LAYOUT NEEDS-PAINT NEEDS-COMPOSITING-BITS-UPDATE
  needs compositing
  parentData: <none> (can use size)
  constraints: BoxConstraints(0.0<=w<=448.0, 0.0<=h<=913.4)
  size: Size(448.0, 913.4)
  axisDirection: down
  crossAxisDirection: right
  offset: _NestedScrollPosition#bae9f(outer, offset: 0.0, range: null..null, viewport: 913.4)
  anchor: 0.0
  handle: SliverOverlapAbsorberHandle(null, orphan)
...  center child: _RenderSliverPinnedPersistentHeaderForWidgets#43acf relayoutBoundary=up1 NEEDS-PAINT NEEDS-COMPOSITING-BITS-UPDATE
...    parentData: paintOffset=Offset(0.0, 0.0) (can use size)
...    constraints: SliverConstraints(AxisDirection.down, GrowthDirection.forward, ScrollDirection.idle, scrollOffset: 0.0, precedingScrollExtent: 0.0, remainingPaintExtent: 913.4, crossAxisExtent: 448.0, crossAxisDirection: AxisDirection.right, viewportMainAxisExtent: 913.4, remainingCacheExtent: 1163.4, cacheOrigin: 0.0)
...    geometry: SliverGeometry(scrollExtent: 384.8, paintExtent: 384.8, maxPaintExtent: 384.8, hasVisualOverflow: true, cacheExtent: 384.8)
...      scrollExtent: 384.8
...      paintExtent: 384.8
...      maxPaintExtent: 384.8
...      hasVisualOverflow: true
...      cacheExtent: 384.8
...    maxExtent: 384.8
...    child position: 0.0
...    child: RenderSemanticsAnnotations#389a3 relayoutBoundary=up2 NEEDS-PAINT NEEDS-COMPOSITING-BITS-UPDATE
...      parentData: <none> (can use size)
...      constraints: BoxConstraints(w=448.0, 0.0<=h<=384.8)
...      semantic boundary
...      size: Size(448.0, 384.8)
...      child: RenderAnnotatedRegion<SystemUiOverlayStyle>#83e6f relayoutBoundary=up3 NEEDS-PAINT NEEDS-COMPOSITING-BITS-UPDATE
...        needs compositing
...        parentData: <none> (can use size)
...        constraints: BoxConstraints(w=448.0, 0.0<=h<=384.8)
...        size: Size(448.0, 384.8)
...        child: RenderPhysicalModel#00151 relayoutBoundary=up4 NEEDS-PAINT NEEDS-COMPOSITING-BITS-UPDATE
...          parentData: <none> (can use size)
...          constraints: BoxConstraints(w=448.0, 0.0<=h<=384.8)
...          size: Size(448.0, 384.8)
...          elevation: 0.0
...          color: Color(alpha: 0.0000, red: 0.0000, green: 0.0000, blue: 0.0000, colorSpace: ColorSpace.sRGB)
...          shadowColor: Color(alpha: 0.0000, red: 0.0000, green: 0.0000, blue: 0.0000, colorSpace: ColorSpace.sRGB)
...          shape: BoxShape.rectangle
...          borderRadius: BorderRadius.zero
...  child 1: RenderSliverToBoxAdapter#9b9c5 relayoutBoundary=up1 NEEDS-PAINT NEEDS-COMPOSITING-BITS-UPDATE
...    parentData: paintOffset=Offset(0.0, 384.8) (can use size)
...    constraints: SliverConstraints(AxisDirection.down, GrowthDirection.forward, ScrollDirection.idle, scrollOffset: 0.0, precedingScrollExtent: 384.8, remainingPaintExtent: 528.6, crossAxisExtent: 448.0, crossAxisDirection: AxisDirection.right, viewportMainAxisExtent: 913.4, remainingCacheExtent: 778.6, cacheOrigin: 0.0)
...    geometry: SliverGeometry(scrollExtent: 78.9, paintExtent: 78.9, maxPaintExtent: 78.9, cacheExtent: 78.9)
...      scrollExtent: 78.9
...      paintExtent: 78.9
...      maxPaintExtent: 78.9
...      cacheExtent: 78.9
...    child: RenderPadding#f959d relayoutBoundary=up2 NEEDS-PAINT NEEDS-COMPOSITING-BITS-UPDATE
...      parentData: paintOffset=Offset(0.0, -0.0) (can use size)
...      constraints: BoxConstraints(w=448.0, 0.0<=h<=Infinity)
...      size: Size(448.0, 78.9)
...      padding: EdgeInsets(0.0, 11.9, 0.0, 11.9)
...      textDirection: ltr
...      child: RenderFlex#dd8ae relayoutBoundary=up3 NEEDS-PAINT NEEDS-COMPOSITING-BITS-UPDATE
...        parentData: offset=Offset(0.0, 11.9) (can use size)
...        constraints: BoxConstraints(w=448.0, 0.0<=h<=Infinity)
...        size: Size(448.0, 55.0)
...        direction: horizontal
...        mainAxisAlignment: spaceEvenly
...        mainAxisSize: max
...        crossAxisAlignment: center
...        textDirection: ltr
...        verticalDirection: down
...        spacing: 0.0
...        child 1: RenderFlex#2ba70 relayoutBoundary=up4 NEEDS-PAINT NEEDS-COMPOSITING-BITS-UPDATE
...          parentData: offset=Offset(79.2, 0.0); flex=null; fit=null (can use size)
...          constraints: BoxConstraints(unconstrained)
...          size: Size(58.3, 55.0)
...          direction: vertical
...          mainAxisAlignment: start
...          mainAxisSize: max
...          crossAxisAlignment: center
...          verticalDirection: down
...          spacing: 0.0
...        child 2: RenderFlex#35a3c relayoutBoundary=up4 NEEDS-PAINT NEEDS-COMPOSITING-BITS-UPDATE
...          parentData: offset=Offset(216.7, 0.0); flex=null; fit=null (can use size)
...          constraints: BoxConstraints(unconstrained)
...          size: Size(43.7, 55.0)
...          direction: vertical
...          mainAxisAlignment: start
...          mainAxisSize: max
...          crossAxisAlignment: center
...          verticalDirection: down
...          spacing: 0.0
...        child 3: RenderFlex#10d30 relayoutBoundary=up4 NEEDS-PAINT NEEDS-COMPOSITING-BITS-UPDATE
...          parentData: offset=Offset(339.6, 0.0); flex=null; fit=null (can use size)
...          constraints: BoxConstraints(unconstrained)
...          size: Size(29.2, 55.0)
...          direction: vertical
...          mainAxisAlignment: start
...          mainAxisSize: max
...          crossAxisAlignment: center
...          verticalDirection: down
...          spacing: 0.0
...  child 2: _RenderSliverPinnedPersistentHeaderForWidgets#a2670 relayoutBoundary=up1 NEEDS-PAINT NEEDS-COMPOSITING-BITS-UPDATE
...    parentData: paintOffset=Offset(0.0, 0.0) (can use size)
...    constraints: SliverConstraints(AxisDirection.down, GrowthDirection.forward, ScrollDirection.idle, scrollOffset: 0.0, precedingScrollExtent: 463.7, remainingPaintExtent: 449.7, crossAxisExtent: 448.0, crossAxisDirection: AxisDirection.right, viewportMainAxisExtent: 913.4, remainingCacheExtent: 699.7, cacheOrigin: 0.0)
...    geometry: SliverGeometry(scrollExtent: 47.8, paintExtent: 47.8, layoutExtent: 47.8, maxPaintExtent: 47.8, hasVisualOverflow: true, cacheExtent: 47.8)
...      scrollExtent: 47.8
...      paintExtent: 47.8
...      layoutExtent: 47.8
...      maxPaintExtent: 47.8
...      hasVisualOverflow: true
...      cacheExtent: 47.8
...    maxExtent: 47.8
...    child position: 0.0
...    child: _RenderColoredBox#09aff relayoutBoundary=up2 NEEDS-PAINT NEEDS-COMPOSITING-BITS-UPDATE
...      parentData: <none> (can use size)
...      constraints: BoxConstraints(w=448.0, 0.0<=h<=47.8)
...      size: Size(448.0, 47.8)
...      behavior: opaque
...      child: RenderPadding#3b49d relayoutBoundary=up3 NEEDS-PAINT NEEDS-COMPOSITING-BITS-UPDATE
...        parentData: <none> (can use size)
...        constraints: BoxConstraints(w=448.0, 0.0<=h<=47.8)
...        size: Size(448.0, 47.8)
...        padding: EdgeInsets(0.0, 7.2, 0.0, 7.2)
...        textDirection: ltr
...        child: RenderDecoratedBox#49c8a relayoutBoundary=up4 NEEDS-PAINT NEEDS-COMPOSITING-BITS-UPDATE
...          parentData: offset=Offset(0.0, 7.2) (can use size)
...          constraints: BoxConstraints(w=448.0, 0.0<=h<=33.5)
...          size: Size(448.0, 33.5)
...          decoration: BoxDecoration
...            color: Color(alpha: 0.0000, red: 0.0000, green: 0.0000, blue: 0.0000, colorSpace: ColorSpace.sRGB)
...            borderRadius: BorderRadius.circular(14.3)
...            boxShadow: BoxShadow(Color(alpha: 0.0500, red: 0.0000, green: 0.0000, blue: 0.0000, colorSpace: ColorSpace.sRGB), Offset(0.0, 2.0), 10.0, 0.0, BlurStyle.normal)
...          configuration: ImageConfiguration(bundle: PlatformAssetBundle#848a2(), devicePixelRatio: 3.0, locale: en, textDirection: TextDirection.ltr, platform: android)
...  child 3: RenderSliverFillRemainingWithScrollable#44188 NEEDS-LAYOUT NEEDS-PAINT NEEDS-COMPOSITING-BITS-UPDATE
...    parentData: paintOffset=Offset(0.0, 0.0)
...    constraints: MISSING
...    geometry: null
...    child: RenderPositionedBox#e2ffb NEEDS-LAYOUT NEEDS-PAINT NEEDS-COMPOSITING-BITS-UPDATE
...      parentData: paintOffset=Offset(0.0, 0.0)
...      constraints: MISSING
...      size: MISSING
...      alignment: Alignment.center
...      textDirection: ltr
...      widthFactor: expand
...      heightFactor: expand
...      child: RenderConstrainedBox#dd041 NEEDS-LAYOUT NEEDS-PAINT NEEDS-COMPOSITING-BITS-UPDATE
...        parentData: offset=Offset(0.0, 0.0)
...        constraints: MISSING
...        size: MISSING
...        additionalConstraints: BoxConstraints(w=119.5, h=119.5)
...        child: RenderPadding#50f47 NEEDS-LAYOUT NEEDS-PAINT NEEDS-COMPOSITING-BITS-UPDATE
...          parentData: <none>
...          constraints: MISSING
...          size: MISSING
...          padding: EdgeInsets(16.7, 0.0, 16.7, 0.0)
...          textDirection: ltr
====================================================================================================

======== Exception caught by rendering library =====================================================
The following _TypeError was thrown during paint():
Null check operator used on a null value

The relevant error-causing widget was: 
  NestedScrollView NestedScrollView:file:///C:/Users/Jooooody/Documents/Linux-DO/lib/pages/profile/profile_page.dart:48:16
When the exception was thrown, this was the stack: 
#0      RenderViewportBase._paintContents (package:flutter/src/rendering/viewport.dart:772:25)
#1      PaintingContext.pushLayer (package:flutter/src/rendering/object.dart:506:12)
#2      PaintingContext.pushClipRect (package:flutter/src/rendering/object.dart:573:7)
#3      RenderViewportBase.paint (package:flutter/src/rendering/viewport.dart:748:38)
#4      RenderObject._paintWithContext (package:flutter/src/rendering/object.dart:3371:7)
#5      PaintingContext._repaintCompositedChild (package:flutter/src/rendering/object.dart:175:11)
#6      PaintingContext.repaintCompositedChild (package:flutter/src/rendering/object.dart:120:5)
#7      PaintingContext._compositeChild (package:flutter/src/rendering/object.dart:271:7)
#8      PaintingContext.paintChild (package:flutter/src/rendering/object.dart:252:7)
#9      RenderProxyBoxMixin.paint (package:flutter/src/rendering/proxy_box.dart:140:13)
#10     RenderObject._paintWithContext (package:flutter/src/rendering/object.dart:3371:7)
#11     PaintingContext.paintChild (package:flutter/src/rendering/object.dart:260:13)
#12     RenderProxyBoxMixin.paint (package:flutter/src/rendering/proxy_box.dart:140:13)
#13     RenderObject._paintWithContext (package:flutter/src/rendering/object.dart:3371:7)
#14     PaintingContext.paintChild (package:flutter/src/rendering/object.dart:260:13)
#15     RenderProxyBoxMixin.paint (package:flutter/src/rendering/proxy_box.dart:140:13)
#16     RenderObject._paintWithContext (package:flutter/src/rendering/object.dart:3371:7)
#17     PaintingContext.paintChild (package:flutter/src/rendering/object.dart:260:13)
#18     RenderProxyBoxMixin.paint (package:flutter/src/rendering/proxy_box.dart:140:13)
#19     RenderObject._paintWithContext (package:flutter/src/rendering/object.dart:3371:7)
#20     PaintingContext.paintChild (package:flutter/src/rendering/object.dart:260:13)
#21     RenderProxyBoxMixin.paint (package:flutter/src/rendering/proxy_box.dart:140:13)
#22     RenderObject._paintWithContext (package:flutter/src/rendering/object.dart:3371:7)
#23     PaintingContext.paintChild (package:flutter/src/rendering/object.dart:260:13)
#24     RenderProxyBoxMixin.paint (package:flutter/src/rendering/proxy_box.dart:140:13)
#25     RenderObject._paintWithContext (package:flutter/src/rendering/object.dart:3371:7)
#26     PaintingContext.paintChild (package:flutter/src/rendering/object.dart:260:13)
#27     RenderProxyBoxMixin.paint (package:flutter/src/rendering/proxy_box.dart:140:13)
#28     RenderTransform.paint (package:flutter/src/rendering/proxy_box.dart:2587:17)
#29     RenderObject._paintWithContext (package:flutter/src/rendering/object.dart:3371:7)
#30     PaintingContext.paintChild (package:flutter/src/rendering/object.dart:260:13)
#31     RenderClipRect.paint (package:flutter/src/rendering/proxy_box.dart:1585:17)
#32     RenderObject._paintWithContext (package:flutter/src/rendering/object.dart:3371:7)
#33     PaintingContext.paintChild (package:flutter/src/rendering/object.dart:260:13)
#34     RenderBoxContainerDefaultsMixin.defaultPaint (package:flutter/src/rendering/box.dart:3360:15)
#35     RenderCustomMultiChildLayoutBox.paint (package:flutter/src/rendering/custom_layout.dart:424:5)
#36     RenderObject._paintWithContext (package:flutter/src/rendering/object.dart:3371:7)
#37     PaintingContext.paintChild (package:flutter/src/rendering/object.dart:260:13)
#38     RenderProxyBoxMixin.paint (package:flutter/src/rendering/proxy_box.dart:140:13)
#39     _RenderInkFeatures.paint (package:flutter/src/material/material.dart:632:11)
#40     RenderObject._paintWithContext (package:flutter/src/rendering/object.dart:3371:7)
#41     PaintingContext.paintChild (package:flutter/src/rendering/object.dart:260:13)
#42     RenderProxyBoxMixin.paint (package:flutter/src/rendering/proxy_box.dart:140:13)
#43     RenderPhysicalModel.paint.<anonymous closure> (package:flutter/src/rendering/proxy_box.dart:2083:15)
#44     PaintingContext.pushClipRRect (package:flutter/src/rendering/object.dart:610:14)
#45     RenderPhysicalModel.paint (package:flutter/src/rendering/proxy_box.dart:2070:21)
#46     RenderObject._paintWithContext (package:flutter/src/rendering/object.dart:3371:7)
#47     PaintingContext.paintChild (package:flutter/src/rendering/object.dart:260:13)
#48     RenderProxyBoxMixin.paint (package:flutter/src/rendering/proxy_box.dart:140:13)
#49     RenderObject._paintWithContext (package:flutter/src/rendering/object.dart:3371:7)
#50     PaintingContext.paintChild (package:flutter/src/rendering/object.dart:260:13)
#51     RenderProxyBoxMixin.paint (package:flutter/src/rendering/proxy_box.dart:140:13)
#52     _RenderVisibility.paint (package:flutter/src/widgets/visibility.dart:607:11)
#53     RenderObject._paintWithContext (package:flutter/src/rendering/object.dart:3371:7)
#54     PaintingContext.paintChild (package:flutter/src/rendering/object.dart:260:13)
#55     RenderIndexedStack.paintStack (package:flutter/src/rendering/stack.dart:864:13)
#56     RenderStack.paint (package:flutter/src/rendering/stack.dart:720:7)
#57     RenderObject._paintWithContext (package:flutter/src/rendering/object.dart:3371:7)
#58     PaintingContext.paintChild (package:flutter/src/rendering/object.dart:260:13)
#59     RenderBoxContainerDefaultsMixin.defaultPaint (package:flutter/src/rendering/box.dart:3360:15)
#60     RenderCustomMultiChildLayoutBox.paint (package:flutter/src/rendering/custom_layout.dart:424:5)
#61     RenderObject._paintWithContext (package:flutter/src/rendering/object.dart:3371:7)
#62     PaintingContext.paintChild (package:flutter/src/rendering/object.dart:260:13)
#63     RenderProxyBoxMixin.paint (package:flutter/src/rendering/proxy_box.dart:140:13)
#64     _RenderInkFeatures.paint (package:flutter/src/material/material.dart:632:11)
#65     RenderObject._paintWithContext (package:flutter/src/rendering/object.dart:3371:7)
#66     PaintingContext.paintChild (package:flutter/src/rendering/object.dart:260:13)
#67     RenderProxyBoxMixin.paint (package:flutter/src/rendering/proxy_box.dart:140:13)
#68     RenderPhysicalModel.paint.<anonymous closure> (package:flutter/src/rendering/proxy_box.dart:2083:15)
#69     PaintingContext.pushClipRRect (package:flutter/src/rendering/object.dart:610:14)
#70     RenderPhysicalModel.paint (package:flutter/src/rendering/proxy_box.dart:2070:21)
#71     RenderObject._paintWithContext (package:flutter/src/rendering/object.dart:3371:7)
#72     PaintingContext.paintChild (package:flutter/src/rendering/object.dart:260:13)
#73     RenderProxyBoxMixin.paint (package:flutter/src/rendering/proxy_box.dart:140:13)
#74     RenderObject._paintWithContext (package:flutter/src/rendering/object.dart:3371:7)
#75     PaintingContext.paintChild (package:flutter/src/rendering/object.dart:260:13)
#76     RenderProxyBoxMixin.paint (package:flutter/src/rendering/proxy_box.dart:140:13)
#77     RenderObject._paintWithContext (package:flutter/src/rendering/object.dart:3371:7)
#78     PaintingContext._repaintCompositedChild (package:flutter/src/rendering/object.dart:175:11)
#79     PaintingContext.repaintCompositedChild (package:flutter/src/rendering/object.dart:120:5)
#80     PipelineOwner.flushPaint (package:flutter/src/rendering/object.dart:1251:31)
#81     PipelineOwner.flushPaint (package:flutter/src/rendering/object.dart:1261:15)
#82     RendererBinding.drawFrame (package:flutter/src/rendering/binding.dart:618:23)
#83     WidgetsBinding.drawFrame (package:flutter/src/widgets/binding.dart:1231:13)
#84     RendererBinding._handlePersistentFrameCallback (package:flutter/src/rendering/binding.dart:482:5)
#85     SchedulerBinding._invokeFrameCallback (package:flutter/src/scheduler/binding.dart:1442:15)
#86     SchedulerBinding.handleDrawFrame (package:flutter/src/scheduler/binding.dart:1355:9)
#87     SchedulerBinding._handleDrawFrame (package:flutter/src/scheduler/binding.dart:1208:5)
#88     _invoke (dart:ui/hooks.dart:316:13)
#89     PlatformDispatcher._drawFrame (dart:ui/platform_dispatcher.dart:428:5)
#90     _drawFrame (dart:ui/hooks.dart:288:31)
The following RenderObject was being processed when the exception was fired: RenderNestedScrollViewViewport#d1d57
...  needs compositing
...  parentData: <none> (can use size)
...  constraints: BoxConstraints(0.0<=w<=448.0, 0.0<=h<=913.4)
...  layer: OffsetLayer#22a66 DETACHED
...    handles: 1
...    offset: Offset(0.0, 0.0)
...  size: Size(448.0, 913.4)
...  axisDirection: down
...  crossAxisDirection: right
...  offset: _NestedScrollPosition#bae9f(outer, offset: 0.0, range: null..null, viewport: 913.4)
...  anchor: 0.0
...  handle: SliverOverlapAbsorberHandle(null, orphan)
RenderObject: RenderNestedScrollViewViewport#d1d57
  needs compositing
  parentData: <none> (can use size)
  constraints: BoxConstraints(0.0<=w<=448.0, 0.0<=h<=913.4)
  layer: OffsetLayer#22a66 DETACHED
    handles: 1
    offset: Offset(0.0, 0.0)
  size: Size(448.0, 913.4)
  axisDirection: down
  crossAxisDirection: right
  offset: _NestedScrollPosition#bae9f(outer, offset: 0.0, range: null..null, viewport: 913.4)
  anchor: 0.0
  handle: SliverOverlapAbsorberHandle(null, orphan)
...  center child: _RenderSliverPinnedPersistentHeaderForWidgets#43acf relayoutBoundary=up1 NEEDS-PAINT
...    needs compositing
...    parentData: paintOffset=Offset(0.0, 0.0) (can use size)
...    constraints: SliverConstraints(AxisDirection.down, GrowthDirection.forward, ScrollDirection.idle, scrollOffset: 0.0, precedingScrollExtent: 0.0, remainingPaintExtent: 913.4, crossAxisExtent: 448.0, crossAxisDirection: AxisDirection.right, viewportMainAxisExtent: 913.4, remainingCacheExtent: 1163.4, cacheOrigin: 0.0)
...    geometry: SliverGeometry(scrollExtent: 384.8, paintExtent: 384.8, maxPaintExtent: 384.8, hasVisualOverflow: true, cacheExtent: 384.8)
...      scrollExtent: 384.8
...      paintExtent: 384.8
...      maxPaintExtent: 384.8
...      hasVisualOverflow: true
...      cacheExtent: 384.8
...    maxExtent: 384.8
...    child position: 0.0
...    child: RenderSemanticsAnnotations#389a3 relayoutBoundary=up2 NEEDS-PAINT
...      needs compositing
...      parentData: <none> (can use size)
...      constraints: BoxConstraints(w=448.0, 0.0<=h<=384.8)
...      semantic boundary
...      size: Size(448.0, 384.8)
...      child: RenderAnnotatedRegion<SystemUiOverlayStyle>#83e6f relayoutBoundary=up3 NEEDS-PAINT
...        needs compositing
...        parentData: <none> (can use size)
...        constraints: BoxConstraints(w=448.0, 0.0<=h<=384.8)
...        size: Size(448.0, 384.8)
...        child: RenderPhysicalModel#00151 relayoutBoundary=up4 NEEDS-PAINT
...          needs compositing
...          parentData: <none> (can use size)
...          constraints: BoxConstraints(w=448.0, 0.0<=h<=384.8)
...          size: Size(448.0, 384.8)
...          elevation: 0.0
...          color: Color(alpha: 0.0000, red: 0.0000, green: 0.0000, blue: 0.0000, colorSpace: ColorSpace.sRGB)
...          shadowColor: Color(alpha: 0.0000, red: 0.0000, green: 0.0000, blue: 0.0000, colorSpace: ColorSpace.sRGB)
...          shape: BoxShape.rectangle
...          borderRadius: BorderRadius.zero
...  child 1: RenderSliverToBoxAdapter#9b9c5 relayoutBoundary=up1 NEEDS-PAINT
...    parentData: paintOffset=Offset(0.0, 384.8) (can use size)
...    constraints: SliverConstraints(AxisDirection.down, GrowthDirection.forward, ScrollDirection.idle, scrollOffset: 0.0, precedingScrollExtent: 384.8, remainingPaintExtent: 528.6, crossAxisExtent: 448.0, crossAxisDirection: AxisDirection.right, viewportMainAxisExtent: 913.4, remainingCacheExtent: 778.6, cacheOrigin: 0.0)
...    geometry: SliverGeometry(scrollExtent: 78.9, paintExtent: 78.9, maxPaintExtent: 78.9, cacheExtent: 78.9)
...      scrollExtent: 78.9
...      paintExtent: 78.9
...      maxPaintExtent: 78.9
...      cacheExtent: 78.9
...    child: RenderPadding#f959d relayoutBoundary=up2 NEEDS-PAINT
...      parentData: paintOffset=Offset(0.0, -0.0) (can use size)
...      constraints: BoxConstraints(w=448.0, 0.0<=h<=Infinity)
...      size: Size(448.0, 78.9)
...      padding: EdgeInsets(0.0, 11.9, 0.0, 11.9)
...      textDirection: ltr
...      child: RenderFlex#dd8ae relayoutBoundary=up3 NEEDS-PAINT
...        parentData: offset=Offset(0.0, 11.9) (can use size)
...        constraints: BoxConstraints(w=448.0, 0.0<=h<=Infinity)
...        size: Size(448.0, 55.0)
...        direction: horizontal
...        mainAxisAlignment: spaceEvenly
...        mainAxisSize: max
...        crossAxisAlignment: center
...        textDirection: ltr
...        verticalDirection: down
...        spacing: 0.0
...        child 1: RenderFlex#2ba70 relayoutBoundary=up4 NEEDS-PAINT
...          parentData: offset=Offset(79.2, 0.0); flex=null; fit=null (can use size)
...          constraints: BoxConstraints(unconstrained)
...          size: Size(58.3, 55.0)
...          direction: vertical
...          mainAxisAlignment: start
...          mainAxisSize: max
...          crossAxisAlignment: center
...          verticalDirection: down
...          spacing: 0.0
...        child 2: RenderFlex#35a3c relayoutBoundary=up4 NEEDS-PAINT
...          parentData: offset=Offset(216.7, 0.0); flex=null; fit=null (can use size)
...          constraints: BoxConstraints(unconstrained)
...          size: Size(43.7, 55.0)
...          direction: vertical
...          mainAxisAlignment: start
...          mainAxisSize: max
...          crossAxisAlignment: center
...          verticalDirection: down
...          spacing: 0.0
...        child 3: RenderFlex#10d30 relayoutBoundary=up4 NEEDS-PAINT
...          parentData: offset=Offset(339.6, 0.0); flex=null; fit=null (can use size)
...          constraints: BoxConstraints(unconstrained)
...          size: Size(29.2, 55.0)
...          direction: vertical
...          mainAxisAlignment: start
...          mainAxisSize: max
...          crossAxisAlignment: center
...          verticalDirection: down
...          spacing: 0.0
...  child 2: _RenderSliverPinnedPersistentHeaderForWidgets#a2670 relayoutBoundary=up1 NEEDS-PAINT
...    parentData: paintOffset=Offset(0.0, 0.0) (can use size)
...    constraints: SliverConstraints(AxisDirection.down, GrowthDirection.forward, ScrollDirection.idle, scrollOffset: 0.0, precedingScrollExtent: 463.7, remainingPaintExtent: 449.7, crossAxisExtent: 448.0, crossAxisDirection: AxisDirection.right, viewportMainAxisExtent: 913.4, remainingCacheExtent: 699.7, cacheOrigin: 0.0)
...    geometry: SliverGeometry(scrollExtent: 47.8, paintExtent: 47.8, layoutExtent: 47.8, maxPaintExtent: 47.8, hasVisualOverflow: true, cacheExtent: 47.8)
...      scrollExtent: 47.8
...      paintExtent: 47.8
...      layoutExtent: 47.8
...      maxPaintExtent: 47.8
...      hasVisualOverflow: true
...      cacheExtent: 47.8
...    maxExtent: 47.8
...    child position: 0.0
...    child: _RenderColoredBox#09aff relayoutBoundary=up2 NEEDS-PAINT
...      parentData: <none> (can use size)
...      constraints: BoxConstraints(w=448.0, 0.0<=h<=47.8)
...      size: Size(448.0, 47.8)
...      behavior: opaque
...      child: RenderPadding#3b49d relayoutBoundary=up3 NEEDS-PAINT
...        parentData: <none> (can use size)
...        constraints: BoxConstraints(w=448.0, 0.0<=h<=47.8)
...        size: Size(448.0, 47.8)
...        padding: EdgeInsets(0.0, 7.2, 0.0, 7.2)
...        textDirection: ltr
...        child: RenderDecoratedBox#49c8a relayoutBoundary=up4 NEEDS-PAINT
...          parentData: offset=Offset(0.0, 7.2) (can use size)
...          constraints: BoxConstraints(w=448.0, 0.0<=h<=33.5)
...          size: Size(448.0, 33.5)
...          decoration: BoxDecoration
...            color: Color(alpha: 0.0000, red: 0.0000, green: 0.0000, blue: 0.0000, colorSpace: ColorSpace.sRGB)
...            borderRadius: BorderRadius.circular(14.3)
...            boxShadow: BoxShadow(Color(alpha: 0.0500, red: 0.0000, green: 0.0000, blue: 0.0000, colorSpace: ColorSpace.sRGB), Offset(0.0, 2.0), 10.0, 0.0, BlurStyle.normal)
...          configuration: ImageConfiguration(bundle: PlatformAssetBundle#848a2(), devicePixelRatio: 3.0, locale: en, textDirection: TextDirection.ltr, platform: android)
...  child 3: RenderSliverFillRemainingWithScrollable#44188 NEEDS-LAYOUT NEEDS-PAINT
...    parentData: paintOffset=Offset(0.0, 0.0)
...    constraints: MISSING
...    geometry: null
...    child: RenderPositionedBox#e2ffb NEEDS-LAYOUT NEEDS-PAINT
...      parentData: paintOffset=Offset(0.0, 0.0)
...      constraints: MISSING
...      size: MISSING
...      alignment: Alignment.center
...      textDirection: ltr
...      widthFactor: expand
...      heightFactor: expand
...      child: RenderConstrainedBox#dd041 NEEDS-LAYOUT NEEDS-PAINT
...        parentData: offset=Offset(0.0, 0.0)
...        constraints: MISSING
...        size: MISSING
...        additionalConstraints: BoxConstraints(w=119.5, h=119.5)
...        child: RenderPadding#50f47 NEEDS-LAYOUT NEEDS-PAINT
...          parentData: <none>
...          constraints: MISSING
...          size: MISSING
...          padding: EdgeInsets(16.7, 0.0, 16.7, 0.0)
...          textDirection: ltr
====================================================================================================

======== Exception caught by rendering library =====================================================
The following assertion was thrown during performLayout():
SliverGeometry is not valid: The "layoutExtent" exceeds the "paintExtent".

The paintExtent is 47.78666666666666, but the layoutExtent is 47.78666666666667.

Maybe you have fallen prey to floating point rounding errors, and should explicitly apply the min() or max() functions, or the clamp() method, to the layoutExtent?

The relevant error-causing widget was: 
  NestedScrollView NestedScrollView:file:///C:/Users/Jooooody/Documents/Linux-DO/lib/pages/profile/profile_page.dart:48:16
When the exception was thrown, this was the stack: 
#0      SliverGeometry.debugAssertIsValid.<anonymous closure>.verify (package:flutter/src/rendering/sliver.dart:868:9)
#1      SliverGeometry.debugAssertIsValid.<anonymous closure> (package:flutter/src/rendering/sliver.dart:880:9)
#2      SliverGeometry.debugAssertIsValid (package:flutter/src/rendering/sliver.dart:903:6)
#3      RenderViewportBase.layoutChildSequence (package:flutter/src/rendering/viewport.dart:630:34)
#4      RenderViewport._attemptLayout (package:flutter/src/rendering/viewport.dart:1576:12)
#5      RenderViewport.performLayout (package:flutter/src/rendering/viewport.dart:1467:20)
#6      RenderObject._layoutWithoutResize (package:flutter/src/rendering/object.dart:2548:7)
#7      PipelineOwner.flushLayout (package:flutter/src/rendering/object.dart:1112:18)
#8      PipelineOwner.flushLayout (package:flutter/src/rendering/object.dart:1125:15)
#9      RendererBinding.drawFrame (package:flutter/src/rendering/binding.dart:616:23)
#10     WidgetsBinding.drawFrame (package:flutter/src/widgets/binding.dart:1231:13)
#11     RendererBinding._handlePersistentFrameCallback (package:flutter/src/rendering/binding.dart:482:5)
#12     SchedulerBinding._invokeFrameCallback (package:flutter/src/scheduler/binding.dart:1442:15)
#13     SchedulerBinding.handleDrawFrame (package:flutter/src/scheduler/binding.dart:1355:9)
#14     SchedulerBinding._handleDrawFrame (package:flutter/src/scheduler/binding.dart:1208:5)
#15     _invoke (dart:ui/hooks.dart:316:13)
#16     PlatformDispatcher._drawFrame (dart:ui/platform_dispatcher.dart:428:5)
#17     _drawFrame (dart:ui/hooks.dart:288:31)
The following RenderObject was being processed when the exception was fired: RenderNestedScrollViewViewport#d1d57 NEEDS-LAYOUT
...  needs compositing
...  parentData: <none> (can use size)
...  constraints: BoxConstraints(0.0<=w<=448.0, 0.0<=h<=913.4)
...  layer: OffsetLayer#22a66
...    engine layer: OffsetEngineLayer#879d7
...    handles: 2
...    offset: Offset(0.0, 0.0)
...  size: Size(448.0, 913.4)
...  axisDirection: down
...  crossAxisDirection: right
...  offset: _NestedScrollPosition#bae9f(outer, offset: 0.0, range: null..null, viewport: 913.4)
...  anchor: 0.0
...  handle: SliverOverlapAbsorberHandle(null, orphan)
RenderObject: RenderNestedScrollViewViewport#d1d57 NEEDS-LAYOUT
  needs compositing
  parentData: <none> (can use size)
  constraints: BoxConstraints(0.0<=w<=448.0, 0.0<=h<=913.4)
  layer: OffsetLayer#22a66
    engine layer: OffsetEngineLayer#879d7
    handles: 2
    offset: Offset(0.0, 0.0)
  size: Size(448.0, 913.4)
  axisDirection: down
  crossAxisDirection: right
  offset: _NestedScrollPosition#bae9f(outer, offset: 0.0, range: null..null, viewport: 913.4)
  anchor: 0.0
  handle: SliverOverlapAbsorberHandle(null, orphan)
...  center child: _RenderSliverPinnedPersistentHeaderForWidgets#43acf relayoutBoundary=up1 NEEDS-PAINT
...    needs compositing
...    parentData: paintOffset=Offset(0.0, 0.0) (can use size)
...    constraints: SliverConstraints(AxisDirection.down, GrowthDirection.forward, ScrollDirection.idle, scrollOffset: 0.0, precedingScrollExtent: 0.0, remainingPaintExtent: 913.4, crossAxisExtent: 448.0, crossAxisDirection: AxisDirection.right, viewportMainAxisExtent: 913.4, remainingCacheExtent: 1163.4, cacheOrigin: 0.0)
...    geometry: SliverGeometry(scrollExtent: 384.8, paintExtent: 384.8, maxPaintExtent: 384.8, hasVisualOverflow: true, cacheExtent: 384.8)
...      scrollExtent: 384.8
...      paintExtent: 384.8
...      maxPaintExtent: 384.8
...      hasVisualOverflow: true
...      cacheExtent: 384.8
...    maxExtent: 384.8
...    child position: 0.0
...    child: RenderSemanticsAnnotations#389a3 relayoutBoundary=up2 NEEDS-PAINT
...      needs compositing
...      parentData: <none> (can use size)
...      constraints: BoxConstraints(w=448.0, 0.0<=h<=384.8)
...      semantic boundary
...      size: Size(448.0, 384.8)
...      child: RenderAnnotatedRegion<SystemUiOverlayStyle>#83e6f relayoutBoundary=up3 NEEDS-PAINT
...        needs compositing
...        parentData: <none> (can use size)
...        constraints: BoxConstraints(w=448.0, 0.0<=h<=384.8)
...        size: Size(448.0, 384.8)
...        child: RenderPhysicalModel#00151 relayoutBoundary=up4 NEEDS-PAINT
...          needs compositing
...          parentData: <none> (can use size)
...          constraints: BoxConstraints(w=448.0, 0.0<=h<=384.8)
...          size: Size(448.0, 384.8)
...          elevation: 0.0
...          color: Color(alpha: 0.0000, red: 0.0000, green: 0.0000, blue: 0.0000, colorSpace: ColorSpace.sRGB)
...          shadowColor: Color(alpha: 0.0000, red: 0.0000, green: 0.0000, blue: 0.0000, colorSpace: ColorSpace.sRGB)
...          shape: BoxShape.rectangle
...          borderRadius: BorderRadius.zero
...  child 1: RenderSliverToBoxAdapter#9b9c5 relayoutBoundary=up1 NEEDS-PAINT
...    parentData: paintOffset=Offset(0.0, 384.8) (can use size)
...    constraints: SliverConstraints(AxisDirection.down, GrowthDirection.forward, ScrollDirection.idle, scrollOffset: 0.0, precedingScrollExtent: 384.8, remainingPaintExtent: 528.6, crossAxisExtent: 448.0, crossAxisDirection: AxisDirection.right, viewportMainAxisExtent: 913.4, remainingCacheExtent: 778.6, cacheOrigin: 0.0)
...    geometry: SliverGeometry(scrollExtent: 78.9, paintExtent: 78.9, maxPaintExtent: 78.9, cacheExtent: 78.9)
...      scrollExtent: 78.9
...      paintExtent: 78.9
...      maxPaintExtent: 78.9
...      cacheExtent: 78.9
...    child: RenderPadding#f959d relayoutBoundary=up2 NEEDS-PAINT
...      parentData: paintOffset=Offset(0.0, -0.0) (can use size)
...      constraints: BoxConstraints(w=448.0, 0.0<=h<=Infinity)
...      size: Size(448.0, 78.9)
...      padding: EdgeInsets(0.0, 11.9, 0.0, 11.9)
...      textDirection: ltr
...      child: RenderFlex#dd8ae relayoutBoundary=up3 NEEDS-PAINT
...        parentData: offset=Offset(0.0, 11.9) (can use size)
...        constraints: BoxConstraints(w=448.0, 0.0<=h<=Infinity)
...        size: Size(448.0, 55.0)
...        direction: horizontal
...        mainAxisAlignment: spaceEvenly
...        mainAxisSize: max
...        crossAxisAlignment: center
...        textDirection: ltr
...        verticalDirection: down
...        spacing: 0.0
...        child 1: RenderFlex#2ba70 relayoutBoundary=up4 NEEDS-PAINT
...          parentData: offset=Offset(79.2, 0.0); flex=null; fit=null (can use size)
...          constraints: BoxConstraints(unconstrained)
...          size: Size(58.3, 55.0)
...          direction: vertical
...          mainAxisAlignment: start
...          mainAxisSize: max
...          crossAxisAlignment: center
...          verticalDirection: down
...          spacing: 0.0
...        child 2: RenderFlex#35a3c relayoutBoundary=up4 NEEDS-PAINT
...          parentData: offset=Offset(216.7, 0.0); flex=null; fit=null (can use size)
...          constraints: BoxConstraints(unconstrained)
...          size: Size(43.7, 55.0)
...          direction: vertical
...          mainAxisAlignment: start
...          mainAxisSize: max
...          crossAxisAlignment: center
...          verticalDirection: down
...          spacing: 0.0
...        child 3: RenderFlex#10d30 relayoutBoundary=up4 NEEDS-PAINT
...          parentData: offset=Offset(339.6, 0.0); flex=null; fit=null (can use size)
...          constraints: BoxConstraints(unconstrained)
...          size: Size(29.2, 55.0)
...          direction: vertical
...          mainAxisAlignment: start
...          mainAxisSize: max
...          crossAxisAlignment: center
...          verticalDirection: down
...          spacing: 0.0
...  child 2: _RenderSliverPinnedPersistentHeaderForWidgets#a2670 relayoutBoundary=up1 NEEDS-PAINT
...    parentData: paintOffset=Offset(0.0, 0.0) (can use size)
...    constraints: SliverConstraints(AxisDirection.down, GrowthDirection.forward, ScrollDirection.idle, scrollOffset: 0.0, precedingScrollExtent: 463.7, remainingPaintExtent: 449.7, crossAxisExtent: 448.0, crossAxisDirection: AxisDirection.right, viewportMainAxisExtent: 913.4, remainingCacheExtent: 699.7, cacheOrigin: 0.0)
...    geometry: SliverGeometry(scrollExtent: 47.8, paintExtent: 47.8, layoutExtent: 47.8, maxPaintExtent: 47.8, hasVisualOverflow: true, cacheExtent: 47.8)
...      scrollExtent: 47.8
...      paintExtent: 47.8
...      layoutExtent: 47.8
...      maxPaintExtent: 47.8
...      hasVisualOverflow: true
...      cacheExtent: 47.8
...    maxExtent: 47.8
...    child position: 0.0
...    child: _RenderColoredBox#09aff relayoutBoundary=up2 NEEDS-PAINT
...      parentData: <none> (can use size)
...      constraints: BoxConstraints(w=448.0, 0.0<=h<=47.8)
...      size: Size(448.0, 47.8)
...      behavior: opaque
...      child: RenderPadding#3b49d relayoutBoundary=up3 NEEDS-PAINT
...        parentData: <none> (can use size)
...        constraints: BoxConstraints(w=448.0, 0.0<=h<=47.8)
...        size: Size(448.0, 47.8)
...        padding: EdgeInsets(0.0, 7.2, 0.0, 7.2)
...        textDirection: ltr
...        child: RenderDecoratedBox#49c8a relayoutBoundary=up4 NEEDS-PAINT
...          parentData: offset=Offset(0.0, 7.2) (can use size)
...          constraints: BoxConstraints(w=448.0, 0.0<=h<=33.5)
...          size: Size(448.0, 33.5)
...          decoration: BoxDecoration
...            color: Color(alpha: 0.0000, red: 0.0000, green: 0.0000, blue: 0.0000, colorSpace: ColorSpace.sRGB)
...            borderRadius: BorderRadius.circular(14.3)
...            boxShadow: BoxShadow(Color(alpha: 0.0500, red: 0.0000, green: 0.0000, blue: 0.0000, colorSpace: ColorSpace.sRGB), Offset(0.0, 2.0), 10.0, 0.0, BlurStyle.normal)
...          configuration: ImageConfiguration(bundle: PlatformAssetBundle#848a2(), devicePixelRatio: 3.0, locale: en, textDirection: TextDirection.ltr, platform: android)
...  child 3: RenderSliverFillRemainingWithScrollable#44188 NEEDS-LAYOUT NEEDS-PAINT
...    parentData: paintOffset=Offset(0.0, 0.0)
...    constraints: MISSING
...    geometry: null
...    child: RenderPositionedBox#e2ffb NEEDS-LAYOUT NEEDS-PAINT
...      parentData: paintOffset=Offset(0.0, 0.0)
...      constraints: MISSING
...      size: MISSING
...      alignment: Alignment.center
...      textDirection: ltr
...      widthFactor: expand
...      heightFactor: expand
...      child: RenderConstrainedBox#dd041 NEEDS-LAYOUT NEEDS-PAINT
...        parentData: offset=Offset(0.0, 0.0)
...        constraints: MISSING
...        size: MISSING
...        additionalConstraints: BoxConstraints(w=119.5, h=119.5)
...        child: RenderPadding#50f47 NEEDS-LAYOUT NEEDS-PAINT
...          parentData: <none>
...          constraints: MISSING
...          size: MISSING
...          padding: EdgeInsets(16.7, 0.0, 16.7, 0.0)
...          textDirection: ltr
====================================================================================================
```

# 设备
出现问题的机型：
Android Studio Virtual Device
![图片](https://github.com/user-attachments/assets/90e12940-b21d-4967-b09d-93d469872be5)

# 问题原因
由于浮点数精度问题导致的，错误信息显示 layoutExtent (47.78666666666667) 略微大于 paintExtent (47.78666666666666)。
要解决这个问题，建议在 SliverPersistentHeader 的 delegate 中使用 clamp() 函数来确保 layoutExtent 不会超过 paintExtent。

# 主要改动
使用计算出的 currentExtent 来明确控制 SizedBox 的高度
这样可以：
确保布局高度在 minHeight 和 maxHeight 之间
避免浮点数精度问题
正确处理滚动时的大小变化